### PR TITLE
Hide Target Temperature when Thermostat is Off

### DIFF
--- a/custom_components/badnest/climate.py
+++ b/custom_components/badnest/climate.py
@@ -188,11 +188,12 @@ class NestClimate(ClimateEntity):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self.device.device_data[self.device_id]['mode'] \
-                != NEST_MODE_HEAT_COOL \
-                and not self.device.device_data[self.device_id]['eco']:
-            return \
-                self.device.device_data[self.device_id]['target_temperature']
+        if (
+            self.device.device_data[self.device_id]["mode"] != NEST_MODE_HEAT_COOL
+            and self.device.device_data[self.device_id]["mode"] != NEST_MODE_OFF
+            and not self.device.device_data[self.device_id]["eco"]
+        ):
+            return self.device.device_data[self.device_id]["target_temperature"]
         return None
 
     @property

--- a/custom_components/badnest/climate.py
+++ b/custom_components/badnest/climate.py
@@ -199,23 +199,21 @@ class NestClimate(ClimateEntity):
     @property
     def target_temperature_high(self):
         """Return the highbound target temperature we try to reach."""
-        if self.device.device_data[self.device_id]['mode'] \
-                == NEST_MODE_HEAT_COOL \
-                and not self.device.device_data[self.device_id]['eco']:
-            return \
-                self.device. \
-                device_data[self.device_id]['target_temperature_high']
+        if (
+            self.device.device_data[self.device_id]["mode"] == NEST_MODE_HEAT_COOL
+            and not self.device.device_data[self.device_id]["eco"]
+        ):
+            return self.device.device_data[self.device_id]["target_temperature_high"]
         return None
 
     @property
     def target_temperature_low(self):
         """Return the lowbound target temperature we try to reach."""
-        if self.device.device_data[self.device_id]['mode'] \
-                == NEST_MODE_HEAT_COOL \
-                and not self.device.device_data[self.device_id]['eco']:
-            return \
-                self.device. \
-                device_data[self.device_id]['target_temperature_low']
+        if (
+            self.device.device_data[self.device_id]["mode"] == NEST_MODE_HEAT_COOL
+            and not self.device.device_data[self.device_id]["eco"]
+        ):
+            return self.device.device_data[self.device_id]["target_temperature_low"]
         return None
 
     @property


### PR DESCRIPTION
When the thermostat is off, the lovelace card would still show a `target temperature`. This adds an additional check to not return the target temperature when the thermostat is off.