### PR TITLE
Fix set_active_sensor Service

### DIFF
--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -442,7 +442,7 @@ class NestAPI():
         if t_device_id not in self.thermostats:
             _LOGGER.warning("Unknown t-stat id: {0}".format(t_device_id))
             return
-        if s_device_id is None: 
+        if s_device_id is None or t_device_id == s_device_id:
             value = {
                 "active_rcs_sensors": [],
                 "rcs_control_setting": "OFF",

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -447,27 +447,28 @@ class NestAPI():
                 "active_rcs_sensors": [],
                 "rcs_control_setting": "OFF",
             }
-        else :
+        else:
             if s_device_id not in self.temperature_sensors:
                 _LOGGER.warning("Unknown Sensor ID: '{0}'".format(s_device_id))
                 return
             value = {
-                "active_rcs_sensors": [ f'kryptonite.{s_device_id}'],
+                "active_rcs_sensors": [f"kryptonite.{s_device_id}"],
                 "rcs_control_setting": "OVERRIDE",
             }
         r = self._session.post(
-            f'{self._czfe_url}/v5/put',
+            f"{self._czfe_url}/v5/put",
             json={
                 "objects": [
                     {
-                        "object_key": f'rcs_settings.{t_device_id}',
+                        "object_key": f"rcs_settings.{t_device_id}",
                         "op": "MERGE",
                         "value": value,
                     }
-                ]            }
+                ]
+            },
         )
         self._check_request(r)
-        
+
     @Decorators.refresh_login
     def thermostat_set_temperature(self, device_id, temp, temp_high=None):
         if device_id not in self.thermostats:

--- a/custom_components/badnest/climate.py
+++ b/custom_components/badnest/climate.py
@@ -293,10 +293,17 @@ class NestClimate(ClimateEntity):
                     self.device_id,
                     temp,
                 )
+
     def set_active_sensor(self, sensor):
-        sensor_id=None
-        if sensor != "" :
-            entity_registry = asyncio.run(self.hass.helpers.entity_registry.async_get_registry())
+        """
+        Set thermostat's active temperature sensor.
+        An empty ("") sensor input defaults the active sensor to being the thermostat's sensor.
+        """
+        sensor_id = None
+        if sensor != "":
+            entity_registry = asyncio.run(
+                self.hass.helpers.entity_registry.async_get_registry()
+            )
             sensor_entity = entity_registry.async_get(sensor)
             sensor_id = sensor_entity.unique_id
         self.device.thermostat_set_active_sensor(
@@ -352,6 +359,6 @@ class NestClimate(ClimateEntity):
     def update(self):
         """Updates data"""
         self.device.update()
-    
+
     def custom_set_active_sensor(entity, **kwargs):
         entity.set_active_sensor(kwargs['sensor'])

--- a/custom_components/badnest/manifest.json
+++ b/custom_components/badnest/manifest.json
@@ -11,5 +11,5 @@
   ],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/custom_components/badnest/services.yaml
+++ b/custom_components/badnest/services.yaml
@@ -1,9 +1,22 @@
 set_active_sensor:
-  description: Changes the active sensor for your Nest thermostat
+  name: Set active sensor
+  description: Changes the active temperature sensor for your Nest thermostat.
   fields:
-    entity_id: 
-        description: The thermostat to operate on
-        example: "climate.nest"
+    entity_id:
+      name: Nest Thermostat
+      description: The Nest thermostat to operate on.
+      example: climate.nest
+      required: true
+      selector:
+        entity:
+          domain: climate
+          integration: badnest
     sensor:
-        description: The Nest temperature sensor to use instead of the one in the thermostat.  Set to "" to go back to the thermostat
-        example: "sensor.bedroom_nest_sensor | \"\""
+      name: Nest Sensor
+      description: The Nest temperature sensor to use as the active sensor.
+      example: sensor.bedroom_nest_sensor
+      required: true
+      selector:
+        entity:
+          domain: sensor
+          integration: badnest


### PR DESCRIPTION
Fixes #3.

A few different changes have been made:

- The `set_active_sensor` service now uses Entity selection fields for the two required inputs and filters entities to only show the valid ones for the service.
- Since the thermostat's sensor entity can be selected, and its device id is the same for both the sensor and thermostat entity, add a check for matching device id to send the proper values to set the thermostat's sensor as the active one.
  - Note: I did leave in the ability to allow an empty `sensor` value, which would still default the active sensor back to the thermostat's sensor.